### PR TITLE
Bug/datetime dtype generation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
-ignore = E501, E203, W503, E265
+ignore = E501, E203, W503, E265, E231
 per-file-ignores = __init__.py:F401
 exclude =
     .git

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 .DS_Store
 **/.DS_Store
+
+.hypothesis/*

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+
+
+v0.0.5:
+- fix column dtype generation/validation bug
+
+## Pre-Publication
 v1.3.0
 - renamed strict_column_set to additionalColumns
 - renamed strict_column_order to exactColumnOrder

--- a/dfschema/core/column.py
+++ b/dfschema/core/column.py
@@ -249,7 +249,7 @@ class ColSchema(BaseModel):
             if not self._dtype_test_func[_dtype](series):
                 txt = _tmplt.format(self.name, series.dtype, _dtype, self.dtype)
                 raise DataFrameValidationError(txt)
-        elif series.dtype != self._dtype:
+        elif series.dtype != _dtype:
             txt = _tmplt.format(self.name, series.dtype, _dtype, self.dtype)
             raise DataFrameValidationError(txt)
 

--- a/dfschema/core/dtype.py
+++ b/dfschema/core/dtype.py
@@ -31,6 +31,7 @@ DtypeAliasPool = {
     "int32": "int",
     "int16": "int",
     # time
+    "datetime64[ns]": "datetime64[ns]",
     "datetime": "datetime64[ns]",
     "date": "datetime64[ns]",
     "timedelta": "timedelta64[ns]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dfschema"
-version = "0.0.4"  # set via gitlab-ci
+version = "0.0.5"  # set via gitlab-ci
 description = "lightweight pandas.DataFrame schema"
 authors = ["Philipp <philippk@zillowgroup.com>"]
 readme = "README.md"

--- a/scripts/generate_jsonschema.py
+++ b/scripts/generate_jsonschema.py
@@ -1,5 +1,5 @@
 if __name__ == "__main__":
-    from dfs.core.core import DfSchema
+    from dfschema.core.core import DfSchema
 
     with open("./jsonschemas/schema.json", "w") as f:
         f.write(DfSchema.schema_json(indent=2))

--- a/scripts/generate_v2.py
+++ b/scripts/generate_v2.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from dfs.core.core import DfSchema
+from dfschema.core.core import DfSchema
 
 
 def get_files(path: Path) -> list:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import json
 def df1():
     return pd.DataFrame({"x": [1, 2, 3, 4], "y": ["foo", "bar", "baz", None]})
 
-    
+
 def df1_hypothesis():
     return data_frames(
         columns=[
@@ -29,11 +29,15 @@ def df2():
 def df3():
     return pd.DataFrame({"x": [np.nan] * 4, "y": ["foo", "bar", "baz", np.nan]})
 
+
 @pytest.fixture()
 def df4():
-    df = pd.DataFrame({"x": [1, 2, 3, 4], "y": ["foo", "bar", "baz", None], 'z': ['2022-10-23',]*4})
-    df['z'] = pd.to_datetime(df['z'])
+    df = pd.DataFrame(
+        {"x": [1, 2, 3, 4], "y": ["foo", "bar", "baz", None], "z": ["2022-10-23",] * 4}
+    )
+    df["z"] = pd.to_datetime(df["z"])
     return df
+
 
 # This section for `test_jsonvalidate.py`
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import json
 def df1():
     return pd.DataFrame({"x": [1, 2, 3, 4], "y": ["foo", "bar", "baz", None]})
 
-
+    
 def df1_hypothesis():
     return data_frames(
         columns=[
@@ -29,6 +29,11 @@ def df2():
 def df3():
     return pd.DataFrame({"x": [np.nan] * 4, "y": ["foo", "bar", "baz", np.nan]})
 
+@pytest.fixture()
+def df4():
+    df = pd.DataFrame({"x": [1, 2, 3, 4], "y": ["foo", "bar", "baz", None], 'z': ['2022-10-23',]*4})
+    df['z'] = pd.to_datetime(df['z'])
+    return df
 
 # This section for `test_jsonvalidate.py`
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -13,7 +13,8 @@ def test_generate_df1(df1):
         raise Exception(sd, e)
 
     S.validate_df(df1)  # type: ignore
-    
+
+
 def test_generate_df1(df4):
     from dfschema.core import DfSchema
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,7 +1,7 @@
 # import pytest
 
 
-def test_generate(df1):
+def test_generate_df1(df1):
     from dfschema.core import DfSchema
 
     print(df1.dtypes)
@@ -13,3 +13,16 @@ def test_generate(df1):
         raise Exception(sd, e)
 
     S.validate_df(df1)  # type: ignore
+    
+def test_generate_df1(df4):
+    from dfschema.core import DfSchema
+
+    print(df4.dtypes)
+
+    try:
+        S = DfSchema.from_df(df4)
+    except Exception as e:  # for debugging
+        sd = DfSchema.from_df(df4, return_dict=True)
+        raise Exception(sd, e)
+
+    S.validate_df(df4)  # type: ignore

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -15,7 +15,7 @@ def test_generate_df1(df1):
     S.validate_df(df1)  # type: ignore
 
 
-def test_generate_df1(df4):
+def test_generate_df4(df4):
     from dfschema.core import DfSchema
 
     print(df4.dtypes)

--- a/tests/test_numeric.py
+++ b/tests/test_numeric.py
@@ -44,10 +44,7 @@ max_min_correct = {
     ],
     "df2": [  # protocol 1.0
         {
-            "columns": {
-                "x": {"min_value": 1},
-                "y": {"dtype": "string"},
-            },
+            "columns": {"x": {"min_value": 1}, "y": {"dtype": "string"},},
             "strict_cols": True,
         },
         {

--- a/tests/test_subsets.py
+++ b/tests/test_subsets.py
@@ -21,11 +21,7 @@ def test_subset_dict(df_subset):
             {
                 "predicate": {"y": "baz"},
                 "columns": [
-                    {
-                        "name": "x",
-                        "dtype": "int",
-                        "value_limits": {"min": 3, "max": 3},
-                    }
+                    {"name": "x", "dtype": "int", "value_limits": {"min": 3, "max": 3},}
                 ],
             },
         ],
@@ -49,11 +45,7 @@ def test_subset_query(df_subset):
                 "predicate": "x >= 3",
                 "shape": {"rows": 2},
                 "columns": [
-                    {
-                        "name": "x",
-                        "dtype": "int",
-                        "value_limits": {"max": 4, "min": 3},
-                    }
+                    {"name": "x", "dtype": "int", "value_limits": {"max": 4, "min": 3},}
                 ],
             },
         ],

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -40,12 +40,7 @@ wrong_schemas = [
     {"shape": {"min_cols": 3}},
     {"columns": ["x", "y", "z"]},
     {"columns": {"x": {"dtype": "floating"}, "y": {"dtype": "floating"}}},
-    {
-        "columns": {
-            "x": {"dtype": "int"},
-            "y": {"dtype": "character", "na_limit": 0.2},
-        }
-    },
+    {"columns": {"x": {"dtype": "int"}, "y": {"dtype": "character", "na_limit": 0.2},}},
 ]
 
 


### PR DESCRIPTION
Fixed bug that led to incorrect `dtype` (not aliase) being passed to object on `DfSchema.from_df` with datetime columns